### PR TITLE
offsetTop getting doubled causing elements to pop to sticky position early

### DIFF
--- a/src/jquery.stickOnScroll.js
+++ b/src/jquery.stickOnScroll.js
@@ -87,7 +87,7 @@
                     // If the current scrollTop position plus the topOffset is greater
                     // than our maxTop value, then make element stick on the page.
                     // if ((scrollTop + o.topOffset) > maxTop) {
-                    if (    (o.isWindow === true && (scrollTop + o.topOffset) > maxTop)
+                    if (    (o.isWindow === true && scrollTop > maxTop)
                         ||  (o.isWindow === false && o.eleTop < scrollTop )
                     ){
                         


### PR DESCRIPTION
Since offsetTop is already subtracted out in maxTop, subtracting it out again in the scrollTop check is effectively doubling the offsetTop, causing elements to pop to sticky position early.
