### PR TITLE
Replaced .scroll() by .trigger("scroll") method

### DIFF
--- a/src/jquery.stickOnScroll.js
+++ b/src/jquery.stickOnScroll.js
@@ -530,7 +530,7 @@
                 viewports[viewportKey].push(o);
 
                 // Trigger a scroll even
-                o.viewport.scroll();
+                o.viewport.trigger("scroll");
 
             } /* end: addThisEleToViewportList() */
 


### PR DESCRIPTION
It will make this plugin compatible with JQuery 3+ out-of-the-box, as .scroll() is a deprecated shorthand.